### PR TITLE
feat: add QR code history feature (stores last 10 generated codes)

### DIFF
--- a/src/Pages/QRGenerator.jsx
+++ b/src/Pages/QRGenerator.jsx
@@ -4,79 +4,135 @@ import QrContext from '../context/QrContext'
 
 const QRGenerator = () => {
   const [Text, setText] = useState("")
-  const { qrValue, setQrValue } = useContext(QrContext)
+
+  const { qrValue, setQrValue, qrHistory, updateQrHistory } = useContext(QrContext)
 
   const generateQR = () => {
     if (!Text.trim()) {
-      setText("");
-      return;
+      setText("")
+      return
     }
 
-    setQrValue(Text);
-  };
+    setQrValue(Text)
+
+    // Save to history
+    updateQrHistory(Text)
+  }
 
   const handleDownload = () => {
     const svg = document.getElementById('qrCode')
-    const svgData = new XMLSerializer().serializeToString(svg);
+    const svgData = new XMLSerializer().serializeToString(svg)
 
     const canvas = document.createElement('canvas')
-    const ctx = canvas.getContext("2d");
+    const ctx = canvas.getContext("2d")
 
-    const img = new Image();
+    const img = new Image()
     img.onload = () => {
-      const border = 40;
+      const border = 40
 
-      canvas.width = img.width + 2 * border;
-      canvas.height = img.height + 2 * border;
+      canvas.width = img.width + 2 * border
+      canvas.height = img.height + 2 * border
 
-      ctx.fillStyle = "white";
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "white"
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
 
-      ctx.drawImage(img, border, border);
+      ctx.drawImage(img, border, border)
 
-      const pngFile = canvas.toDataURL("image/png");
+      const pngFile = canvas.toDataURL("image/png")
 
-      const downloadLink = document.createElement("a");
-      downloadLink.download = "QR-Code.png";
-      downloadLink.href = pngFile;
-      downloadLink.click();
+      const downloadLink = document.createElement("a")
+      downloadLink.download = "QR-Code.png"
+      downloadLink.href = pngFile
+      downloadLink.click()
     }
 
-    img.src = "data:image/svg+xml;base64," + btoa(svgData);
+    img.src = "data:image/svg+xml;base64," + btoa(svgData)
   }
 
   return (
     <div className='min-h-screen'>
-      <div className='flex justify-center items-center py-4'>
-        <p className='text-2xl font-bold tracking-wide sm:text-4xl'>QR Code Generator</p>
-      </div>
-      <div className='flex justify-center items-center pt-5'>
-        <div className=' flex flex-col justify-center items-center gap-5  w-[75%] sm:max-w-[65%] lg:max-w-[40%] bg-linear-to-r from-purple-300 to-indigo-300 p-5 border-none rounded-2xl'>
-          <input type="text" placeholder='Enter text or URL'
-            className="border-2 rounded-lg pr-5 p-2 w-full bg-gray-300 border-none text-[20px] font-medium text-gray-950 "
-            value={Text} onChange={(e) => { setText(e.target.value) }} />
 
-          <button className='bg-black p-2 px-4 text-white rounded-lg font-bold cursor-pointer' onClick={generateQR}>Genrate QR</button>
+      <div className='flex justify-center items-center py-4'>
+        <p className='text-2xl font-bold tracking-wide sm:text-4xl'>
+          QR Code Generator
+        </p>
+      </div>
+
+      <div className='flex justify-center items-center pt-5'>
+        <div className='flex flex-col justify-center items-center gap-5 w-[75%] sm:max-w-[65%] lg:max-w-[40%] bg-linear-to-r from-purple-300 to-indigo-300 p-5 border-none rounded-2xl'>
+
+          <input
+            type="text"
+            placeholder='Enter text or URL'
+            className="border-2 rounded-lg pr-5 p-2 w-full bg-gray-300 border-none text-[20px] font-medium text-gray-950"
+            value={Text}
+            onChange={(e) => setText(e.target.value)}
+          />
+
+          <button
+            className='bg-black p-2 px-4 text-white rounded-lg font-bold cursor-pointer'
+            onClick={generateQR}
+          >
+            Generate QR
+          </button>
 
           {qrValue ? (
-            <div className='flex justify-center items-center bg-white border-none rounded-[10px] w-40 h-40 p-4 sm:w-52 sm:h-52 lg:w-60 lg:h-60' >
-              <QRCode id='qrCode' value={qrValue} size={128}
+            <div className='flex justify-center items-center bg-white border-none rounded-[10px] w-40 h-40 p-4 sm:w-52 sm:h-52 lg:w-60 lg:h-60'>
+              <QRCode
+                id='qrCode'
+                value={qrValue}
+                size={128}
                 level="H"
-                style={{ 
-                  height: "auto", 
-                  maxWidth: "100%", 
-                  width: "100%" 
-                }} bgColor="white" fgColor="black" />
+                style={{
+                  height: "auto",
+                  maxWidth: "100%",
+                  width: "100%"
+                }}
+                bgColor="white"
+                fgColor="black"
+              />
             </div>
           ) : (
-            <p className="text-gray-950 text-center">Type something to generate QR</p>
+            <p className="text-gray-950 text-center">
+              Type something to generate QR
+            </p>
           )}
 
           {qrValue && (
-            <button className='bg-green-400 p-2 text-gray-500 hover:text-white border-green-400 rounded-lg font-bold' onClick={handleDownload}>Download</button>
+            <button
+              className='bg-green-400 p-2 text-gray-500 hover:text-white border-green-400 rounded-lg font-bold'
+              onClick={handleDownload}
+            >
+              Download
+            </button>
           )}
+
+          {/* QR HISTORY SECTION */}
+          {qrHistory && qrHistory.length > 0 && (
+            <div className="w-full mt-4">
+
+              <p className="text-lg font-bold text-center mb-2">
+                Recent QR Codes
+              </p>
+
+              <div className="flex flex-col gap-2 max-h-40 overflow-y-auto">
+                {qrHistory.map((item, index) => (
+                  <button
+                    key={index}
+                    onClick={() => setQrValue(item)}
+                    className="bg-white text-gray-900 rounded-md p-2 hover:bg-gray-200 text-sm font-medium"
+                  >
+                    {item}
+                  </button>
+                ))}
+              </div>
+
+            </div>
+          )}
+
         </div>
       </div>
+
     </div>
   )
 }

--- a/src/context/QrStates.jsx
+++ b/src/context/QrStates.jsx
@@ -1,13 +1,53 @@
-import React, { useState } from 'react'
-import QrContext from './QrContext'
+import React, { useState } from "react";
+import QrContext from "./QrContext";
 
 const QrStates = (props) => {
-  const [qrValue, setQrValue] = useState("")
+
+  // Current QR value
+  const [qrValue, setQrValue] = useState("");
+
+  // Load history from localStorage
+  const [qrHistory, setQrHistory] = useState(
+    JSON.parse(localStorage.getItem("qrHistory")) || []
+  );
+
+  // Function to update history
+  const updateQrHistory = (value) => {
+
+    if (!value) return;
+
+    let updatedHistory = [
+      value,
+      ...qrHistory.filter((item) => item !== value)
+    ];
+
+    // Keep only last 10
+    updatedHistory = updatedHistory.slice(0, 10);
+
+    setQrHistory(updatedHistory);
+
+    localStorage.setItem("qrHistory", JSON.stringify(updatedHistory));
+  };
+
+  // Optional: clear history
+  const clearQrHistory = () => {
+    setQrHistory([]);
+    localStorage.removeItem("qrHistory");
+  };
+
   return (
-    <QrContext.Provider value={{qrValue, setQrValue}}>
+    <QrContext.Provider
+      value={{
+        qrValue,
+        setQrValue,
+        qrHistory,
+        updateQrHistory,
+        clearQrHistory
+      }}
+    >
       {props.children}
     </QrContext.Provider>
-  )
-}
+  );
+};
 
-export default QrStates
+export default QrStates;


### PR DESCRIPTION
Fixes #<issue-number>

## Summary

This PR introduces a **QR Code History feature** that allows users to access recently generated QR codes. The feature stores the last 10 QR inputs and displays them in a dedicated "Recent QR Codes" section.

## Changes Made

- Added QR history state management using React Context
- Implemented storage of QR inputs in `localStorage`
- Limited history to the **last 10 generated QR codes**
- Displayed a **Recent QR Codes** section in the UI
- Enabled users to click a history item to regenerate the QR code

## How It Works

1. When a user generates a QR code, the input value is stored in history.
2. The history is saved in `localStorage` to persist across page reloads.
3. The most recent entries are displayed below the QR generator.
4. Clicking a history item regenerates the QR code instantly.


I made some modifications in these course file in order to implement the changes:
- `src/context/QrStates.jsx`
- `src/Pages/QRGenerator.jsx`

## Screenshots
<img width="1470" height="881" alt="Screenshot 2026-03-13 at 12 27 40 AM" src="https://github.com/user-attachments/assets/78f8041a-ba9d-408b-92c9-80da7c866820" />

## Result

Users can now quickly access and reuse previously generated QR codes, improving usability and workflow efficiency.